### PR TITLE
Rekommendera SpotBugs istället för FindBugs

### DIFF
--- a/Q51.org
+++ b/Q51.org
@@ -1,7 +1,7 @@
 #+html: <a name="51"></a>
 ** TODO Q51: Andra verktyg för felsökning :G5:Report:
 
- Använd [[http://findbugs.sourceforge.net][Findbugs]] på ett eller flera av de Javaprogram som du har
+ Använd [[https://spotbugs.github.io/][SpotBugs]] på ett eller flera av de Javaprogram som du har
  utvecklat under kursen och studera resultatet. Hittar du buggar i
  programmet? Får du s.k. "false positives", alltså rapporter om fel
  som inte är fel i praktiken?


### PR DESCRIPTION
SpotBugs är en fork och "spiritual successor" till Findbugs som flera studenter har demonstrerat målet med redan. Många har rapporterat problem med att använda Findbugs, som inte har uppdaterats sedan 2015.

Kanske vill vi inte merga den här ändringen under föregående kurs; jag ser både för- och nackdelar.